### PR TITLE
Fix crash because of nil translucent_bg

### DIFF
--- a/playtestthread.lua
+++ b/playtestthread.lua
@@ -191,11 +191,16 @@ while true do
         v_lib.set_volume(data.music_volume)
         v_lib.set_sound_volume(data.sfx_volume)
 
+        local translucent_bg
         if (vvvvvv_settings.translucent_bg == nil) then
-            v_lib.set_roomname_bg(data.ved_translucent_bg)
+            translucent_bg = data.ved_translucent_bg
         else
-            v_lib.set_roomname_bg(vvvvvv_settings.translucent_bg)
+            translucent_bg = vvvvvv_settings.translucent_bg
         end
+        if translucent_bg == nil then
+            translucent_bg = false
+        end
+        v_lib.set_roomname_bg(translucent_bg)
     elseif data.type == "stop" then
         v_lib.return_to_idlemode()
     elseif data.type == "imagedata" then


### PR DESCRIPTION
This PR attempts to fix this error I got:
```
plugins/ved-vlib/playtestthread.lua:195: bad argument #1 to 'set_roomname_bg' (cannot convert 'nil' to 'bool')
stack traceback:
	[C]: in function 'set_roomname_bg'
	plugins/ved-vlib/playtestthread.lua:195: in main chunk
```

![The error but in a dialog](https://github.com/NyakoFox/ved-vlib/assets/44736680/e9cb66af-c93a-4e4d-9ced-dd782c84ae2f)

(I'm not sure if this is the best fix because I don't know what I'm doing in this codebase so it's worth checking, but it fixed it for me.)